### PR TITLE
fix: wildcard matching in browsers INTER-1776

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,3 +6,27 @@ jobs:
   build-and-check:
     name: Build project and run CI checks
     uses: fingerprintjs/dx-team-toolkit/.github/workflows/build-typescript-project.yml@v1
+
+  playwright-tests:
+    name: Playwright tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm build
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium --with-deps
+      - name: Run Playwright tests
+        run: pnpm test:playwright

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ coverage.txt
 .vscode/
 yarn-error.log
 docs
+
+# tests
+test-results/

--- a/README.md
+++ b/README.md
@@ -221,6 +221,25 @@ try {
 }
 ```
 
+## Testing
+
+Unit tests:
+
+```sh
+pnpm test
+```
+
+Playwright tests:
+
+```sh
+pnpm exec playwright install chromium
+pnpm test:playwright
+```
+
+Playwright tests are required to test scenarions where browser behaves differently from Node.
+For example, the browser `URL()` constructor cannot parse wildcards like `*.example.com` correctly, but Node tests 
+wouldn't catch it.
+
 ## API Reference
 
 See the full [generated API reference](https://fingerprintjs.github.io/url-matcher/).

--- a/__tests__/matcher.test.ts
+++ b/__tests__/matcher.test.ts
@@ -3,6 +3,10 @@ import { cloudflareMatchUrl } from './cloudflare'
 import { findMatchingRoute, InvalidPatternError, InvalidProtocolError, matchesPatterns, parseRoutes } from '../src'
 
 describe('Matcher', () => {
+  it('should work for patterns starting with a wildcard', () => {
+    expect(matchesPatterns(new URL('https://sub.example.com'), ['*.example.com'])).toBe(true)
+  })
+
   // Based on miniflare behaviour
   it('should throw for an infix wildcard', () => {
     expect(() =>
@@ -14,7 +18,14 @@ describe('Matcher', () => {
       )
     )
   })
-
+  it('should throw for an infix wildcard and a wildcard host', () => {
+    expect(() => matchesPatterns(new URL('https://example.com/blog/2025/post-1'), ['*/blog/*/post-*'])).toThrow(
+      new InvalidPatternError(
+        'Route "*/blog/*/post-*" contains an infix wildcard. This is not allowed.',
+        'ERR_INFIX_WILDCARD'
+      )
+    )
+  })
   it('should throw if pattern contains query string', () => {
     expect(() =>
       matchesPatterns(new URL('https://example.com/blog/2025/post-1'), ['fingerprint.com/blog/post123?q=test'])

--- a/__tests__/matcher.test.ts
+++ b/__tests__/matcher.test.ts
@@ -60,8 +60,8 @@ describe('Matcher', () => {
       new InvalidPatternError('Route "/path" is missing a hostname. This is not allowed.', 'ERR_INVALID_URL')
     )
   })
-  
-    it('should throw for a missing hostname', () => {
+
+  it('should throw for a missing hostname', () => {
     expect(() => matchesPatterns(new URL('https://example.com'), ['https:///path'])).toThrow(
       new InvalidPatternError('Route "https:///path" is missing a hostname. This is not allowed.', 'ERR_INVALID_URL')
     )

--- a/__tests__/matcher.test.ts
+++ b/__tests__/matcher.test.ts
@@ -55,6 +55,23 @@ describe('Matcher', () => {
     )
   })
 
+  it('should throw for just a path as the pattern', () => {
+    expect(() => matchesPatterns(new URL('https://example.com'), ['/path'])).toThrow(
+      new InvalidPatternError('Route "/path" is missing a hostname. This is not allowed.', 'ERR_INVALID_URL')
+    )
+  })
+  
+    it('should throw for a missing hostname', () => {
+    expect(() => matchesPatterns(new URL('https://example.com'), ['https:///path'])).toThrow(
+      new InvalidPatternError('Route "https:///path" is missing a hostname. This is not allowed.', 'ERR_INVALID_URL')
+    )
+  })
+
+  it('should throw for just a protocol', () => {
+    expect(() => matchesPatterns(new URL('https://example.com'), ['https://'])).toThrow(
+      new InvalidPatternError('Pattern https:// is not a valid URL', 'ERR_INVALID_URL')
+    )
+  })
   it('should return metadata of the matched route if it was set', () => {
     const routes = parseRoutes([
       {

--- a/__tests__/parser.test.ts
+++ b/__tests__/parser.test.ts
@@ -1,0 +1,134 @@
+import { InvalidPatternError } from '../src/errors'
+import { normalizeWildcardHostname, parseRoutes, splitUrlInput } from '../src/parser'
+
+describe('splitUrlInput', () => {
+  it('returns null when protocol is missing', () => {
+    expect(splitUrlInput('example.com/path')).toBeNull()
+  })
+
+  it('returns null when protocol contains invalid characters', () => {
+    expect(splitUrlInput('ht^tp://example.com')).toBeNull()
+  })
+
+  it('returns parts when there is a path', () => {
+    const result = splitUrlInput('https://example.com/path?query=1')
+
+    expect(result).toEqual({
+      protocolPrefix: 'https://',
+      hostname: 'example.com',
+      rest: '/path?query=1',
+    })
+  })
+
+  it('returns parts when there is no path', () => {
+    const result = splitUrlInput('https://example.com')
+
+    expect(result).toEqual({
+      protocolPrefix: 'https://',
+      hostname: 'example.com',
+      rest: '',
+    })
+  })
+
+  it('keeps wildcard hostnames intact', () => {
+    const result = splitUrlInput('https://*.example.com/path')
+
+    expect(result).toEqual({
+      protocolPrefix: 'https://',
+      hostname: '*.example.com',
+      rest: '/path',
+    })
+  })
+
+  it('preserves protocol casing when present', () => {
+    const result = splitUrlInput('HTTPS://example.com/path')
+
+    expect(result).toEqual({
+      protocolPrefix: 'HTTPS://',
+      hostname: 'example.com',
+      rest: '/path',
+    })
+  })
+})
+
+describe('normalizeWildcardHostname', () => {
+  it('replaces wildcard with placeholder in hostname', () => {
+    const urlInput = 'https://*.example.com/path'
+    const urlParts = splitUrlInput(urlInput)
+
+    const result = normalizeWildcardHostname(urlInput, urlParts)
+
+    expect(result).toBe('https://wildcard.example.com/path')
+  })
+
+  it('returns input unchanged when hostname does not start with wildcard', () => {
+    const urlInput = 'https://example.com/path'
+    const urlParts = splitUrlInput(urlInput)
+
+    const result = normalizeWildcardHostname(urlInput, urlParts)
+
+    expect(result).toBe(urlInput)
+  })
+})
+
+describe('parseRoutes', () => {
+  it('parses wildcard hostname prefix and strips the leading "*"', () => {
+    const [route] = parseRoutes(['*.example.com/path'])
+
+    expect(route.wildcardHostnamePrefix).toBe(true)
+    expect(route.hostname).toBe('.example.com')
+    expect(route.path).toBe('/path')
+    expect(route.wildcardPathSuffix).toBe(false)
+  })
+
+  it('parses wildcard path suffix and strips trailing "*"', () => {
+    const [route] = parseRoutes(['example.com/path/*'])
+
+    expect(route.wildcardPathSuffix).toBe(true)
+    expect(route.path).toBe('/path/')
+  })
+
+  it('parses wildcard hostname with port', () => {
+    const [route] = parseRoutes(['*.example.com:8080/path'])
+
+    expect(route.hostname).toBe('.example.com')
+    expect(route.wildcardHostnamePrefix).toBe(true)
+    expect(route.path).toBe('/path')
+  })
+
+  it('parses pattern with both wildcard hostname prefix and path suffix', () => {
+    const [route] = parseRoutes(['*.example.com/api/*'])
+
+    expect(route.wildcardHostnamePrefix).toBe(true)
+    expect(route.hostname).toBe('.example.com')
+    expect(route.wildcardPathSuffix).toBe(true)
+    expect(route.path).toBe('/api/')
+  })
+
+  it('throws for hostname infix wildcard', () => {
+    expect(() => parseRoutes(['ex*ample.com'])).toThrow(
+      new InvalidPatternError(
+        'Route "ex*ample.com" contains an infix wildcard. This is not allowed.',
+        'ERR_INFIX_WILDCARD'
+      )
+    )
+  })
+
+  it('throws for path infix wildcard', () => {
+    expect(() => parseRoutes(['example.com/pa*th'])).toThrow(
+      new InvalidPatternError(
+        'Route "example.com/pa*th" contains an infix wildcard. This is not allowed.',
+        'ERR_INFIX_WILDCARD'
+      )
+    )
+  })
+
+  it('throws for query string in routes', () => {
+    expect(() => parseRoutes(['example.com/path?query=1'])).toThrow(
+      new InvalidPatternError(
+        'Route "example.com/path?query=1" contains a query string. This is not allowed.',
+        'ERR_QUERY_STRING'
+      )
+    )
+  })
+})

--- a/__tests__/parser.test.ts
+++ b/__tests__/parser.test.ts
@@ -30,6 +30,15 @@ describe('splitUrlInput', () => {
     })
   })
 
+  it('returns parts when there is no hostname', () => {
+    const result = splitUrlInput('https:///path')
+
+    expect(result).toEqual({
+      protocolPrefix: 'https://',
+      hostname: '',
+      rest: '/path',
+    })
+  })
   it('keeps wildcard hostnames intact', () => {
     const result = splitUrlInput('https://*.example.com/path')
 

--- a/__tests__/playwright/matcher.spec.ts
+++ b/__tests__/playwright/matcher.spec.ts
@@ -2,6 +2,8 @@ import { test, expect, Page } from '@playwright/test'
 import { resolve } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
+// Expecially importart to test `*` handling in the browser context
+// instead of node unit tests since URL() behavior differs.
 test('matches wildcard subdomain with full path in browser context', async ({ page }) => {
   await runMatcherTest(page, {
     url: 'https://specific-subdomain.example.test/path',
@@ -31,6 +33,16 @@ test('does not match when path differs in browser context', async ({ page }) => 
     url: 'https://subdomain.example.test/different-path',
     patterns: ['*.example.test/some-path'],
     expected: false,
+  })
+})
+
+// But also just run all test cases also with Playwright, just in case.
+import testCases from '../testCases.json'
+testCases.forEach((testCase, index) => {
+  test(`#${index + 1} ${testCase.expected ? 'matches' : 'does not match'} for ${testCase.url} with ${testCase.patterns.join(',')}`, async ({
+    page,
+  }) => {
+    await runMatcherTest(page, testCase)
   })
 })
 

--- a/__tests__/playwright/matcher.spec.ts
+++ b/__tests__/playwright/matcher.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect, Page } from '@playwright/test'
+import { resolve } from 'node:path'
+import { readFile } from 'node:fs/promises'
+
+test('matches wildcard subdomain with full path in browser context', async ({ page }) => {
+  await runMatcherTest(page, {
+    url: 'https://specific-subdomain.example.test/path',
+    patterns: ['*.example.test/path'],
+    expected: true,
+  })
+})
+
+test('matches wildcard subdomain AND wildcard suffix in path in browser context', async ({ page }) => {
+  await runMatcherTest(page, {
+    url: 'https://sub.example.test/api/users/123',
+    patterns: ['*.example.test/api/users/*'],
+    expected: true,
+  })
+})
+
+test('matches PARTIAL wildcard subdomain AND wildcard suffix in path in browser context', async ({ page }) => {
+  await runMatcherTest(page, {
+    url: 'https://some-subdomain.example.test/api/users/123',
+    patterns: ['*-subdomain.example.test/api/users/*'],
+    expected: true,
+  })
+})
+
+test('does not match when path differs in browser context', async ({ page }) => {
+  await runMatcherTest(page, {
+    url: 'https://subdomain.example.test/different-path',
+    patterns: ['*.example.test/some-path'],
+    expected: false,
+  })
+})
+
+const modulePath = resolve(__dirname, '../../dist/index.esm.js')
+
+declare global {
+  interface Window {
+    __result?: boolean
+    __error?: string
+  }
+}
+
+interface MatcherTestCase {
+  url: string
+  patterns: string[]
+  expected: boolean
+}
+
+async function runMatcherTest(page: Page, { url, patterns, expected }: MatcherTestCase): Promise<void> {
+  const moduleCode = await readFile(modulePath, 'utf8')
+  const appUrl = 'http://url-matcher.test'
+  const moduleUrl = `${appUrl}/index.esm.js`
+
+  const patternsJson = JSON.stringify(patterns)
+
+  await page.route(`${appUrl}/`, async (route) => {
+    const html = `<!doctype html>
+      <meta charset="utf-8">
+      <script type="module">
+        import { matchesPatterns } from '${moduleUrl}';
+        try {
+          window.__result = matchesPatterns(
+            new URL('${url}'),
+            ${patternsJson}
+          );
+        } catch (error) {
+          window.__error = String(error);
+        }
+      </script>`
+    await route.fulfill({ status: 200, contentType: 'text/html', body: html })
+  })
+
+  await page.route(moduleUrl, async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/javascript', body: moduleCode })
+  })
+
+  await page.goto(appUrl)
+  await page.waitForFunction(() => window.__result !== undefined || window.__error !== undefined)
+
+  const error = await page.evaluate(() => window.__error ?? null)
+  expect(error).toBeNull()
+
+  const result = await page.evaluate(() => window.__result)
+  expect(result).toBe(expected)
+}

--- a/__tests__/testCases.json
+++ b/__tests__/testCases.json
@@ -269,5 +269,19 @@
       "español.com"
     ],
     "expected": true
+  },
+  {
+    "url": "https://sub.example.com/some/path",
+    "patterns": [
+      "*.example.com/some/path"
+    ],
+    "expected": true
+  },
+  {
+    "url": "https://example.com/some/path",
+    "patterns": [
+      "*.example.com/some/path"
+    ],
+    "expected": false
   }
 ]

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint --ext .js,.ts --ignore-path .gitignore --max-warnings 0 .",
     "lint:fix": "yarn lint --fix",
     "test": "jest",
+    "test:playwright": "pnpm build && playwright test",
     "test:coverage": "jest --coverage",
     "test:dts": "tsc --noEmit --isolatedModules dist/index.d.ts",
     "docs": "typedoc src/index.ts --out docs"
@@ -44,6 +45,7 @@
     "@fingerprintjs/eslint-config-dx-team": "^0.1.0",
     "@fingerprintjs/prettier-config-dx-team": "^0.2.0",
     "@fingerprintjs/tsconfig-dx-team": "^0.0.2",
+    "@playwright/test": "^1.57.0",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/jest": "^29.5.14",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: '__tests__/playwright',
+  timeout: 30_000,
+  use: {
+    headless: true,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        browserName: 'chromium',
+      },
+    },
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@fingerprintjs/tsconfig-dx-team':
         specifier: ^0.0.2
         version: 0.0.2
+      '@playwright/test':
+        specifier: ^1.57.0
+        version: 1.57.0
       '@rollup/plugin-json':
         specifier: ^6.1.0
         version: 6.1.0(rollup@4.38.0)
@@ -679,6 +682,11 @@ packages:
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@poppinss/colors@4.1.5':
     resolution: {integrity: sha512-FvdDqtcRCtz6hThExcFOgW0cWX+xwSMWcRuQe5ZEb2m7cVQOAVZOIMt+/v9RxGiD9/OY16qJBXK4CVKWAPalBw==}
@@ -1689,6 +1697,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2546,6 +2559,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -3909,6 +3932,10 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
+  '@playwright/test@1.57.0':
+    dependencies:
+      playwright: 1.57.0
+
   '@poppinss/colors@4.1.5':
     dependencies:
       kleur: 4.1.5
@@ -4943,6 +4970,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5971,6 +6001,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.57.0: {}
+
+  playwright@1.57.0:
+    dependencies:
+      playwright-core: 1.57.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   prelude-ls@1.2.1: {}
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -108,6 +108,9 @@ export function parseRoutes<Metadata>(
     const urlInputForParse = normalizeWildcardHostname(urlInput, urlParts)
     const url = parsePatternUrl(urlInputForParse)
 
+    if (!urlParts?.hostname) {
+      throw new InvalidPatternError(`Route "${route}" is missing a hostname. This is not allowed.`, 'ERR_INVALID_URL')
+    }
     let protocol: Protocol | undefined
     if (hasProtocol) {
       validateProtocol(url.protocol)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4,7 +4,6 @@ import { InvalidPatternError } from './errors'
 
 const WILDCARD_HOSTNAME_PLACEHOLDER = 'wildcard'
 const PROTOCOL_SEPARATOR = '://'
-const PROTOCOL_PATTERN = /^[a-z0-9+\-.]+$/i
 
 export type UrlParts = {
   protocolPrefix: string
@@ -12,31 +11,24 @@ export type UrlParts = {
   rest: string
 }
 
+// (protocol)://(hostname)(rest including path, query, fragment)
+const URL_PARTS_PATTERN = /^([a-z0-9+\-.]+:\/\/)([^/]*)(.*)$/i
+
 /**
  * The reason we require manually parsing URLs instead of just passing it to URL()
  * is that URL() constructor in the browser cannot handle parsing wildcards like `*.example.com`.
  * Which is not obvious, since new URL('*.example.com') works in Node.
  */
 export function splitUrlInput(urlInput: string): UrlParts | null {
-  const protocolIndex = urlInput.indexOf(PROTOCOL_SEPARATOR)
-  if (protocolIndex <= 0) {
-    // Fully qualified URLs (including protocol) are expected
+  const match = URL_PARTS_PATTERN.exec(urlInput)
+  if (!match) {
     return null
   }
-
-  const protocol = urlInput.slice(0, protocolIndex)
-  if (!PROTOCOL_PATTERN.test(protocol)) {
-    return null
-  }
-
-  const hostnameStart = protocolIndex + PROTOCOL_SEPARATOR.length
-  const pathStart = urlInput.indexOf('/', hostnameStart)
-  const hostnameEnd = pathStart === -1 ? urlInput.length : pathStart
 
   return {
-    protocolPrefix: urlInput.slice(0, hostnameStart),
-    hostname: urlInput.slice(hostnameStart, hostnameEnd),
-    rest: urlInput.slice(hostnameEnd),
+    protocolPrefix: match[1],
+    hostname: match[2],
+    rest: match[3],
   }
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -111,7 +111,7 @@ export function parseRoutes<Metadata>(
 
     const allowHostnamePrefix = rawHostname.startsWith('*')
     const anyHostname = rawHostname === '*'
-    const allowPathSuffix = url.pathname.endsWith('*')
+    const hasWildcardPathSuffix = url.pathname.endsWith('*')
     const specificity = sortBySpecificity ? routeSpecificity(rawHostname, url.pathname) : undefined
 
     let hostname = url.hostname
@@ -123,9 +123,10 @@ export function parseRoutes<Metadata>(
     const hostnameHasInfixWildcard = allowHostnamePrefix
       ? rawHostname.slice(1).includes('*')
       : rawHostname.includes('*')
-    const pathHasInfixWildcard = pathContainsWildcard && (!allowPathSuffix || url.pathname.slice(0, -1).includes('*'))
+    const pathHasInfixWildcard =
+      pathContainsWildcard && (!hasWildcardPathSuffix || url.pathname.slice(0, -1).includes('*'))
 
-    if (allowPathSuffix) {
+    if (hasWildcardPathSuffix) {
       // Remove trailing "*"
       url.pathname = url.pathname.substring(0, url.pathname.length - 1)
     }
@@ -151,7 +152,7 @@ export function parseRoutes<Metadata>(
       wildcardHostnamePrefix: allowHostnamePrefix,
       hostname: anyHostname ? '' : hostname,
       path: url.pathname,
-      wildcardPathSuffix: allowPathSuffix,
+      wildcardPathSuffix: hasWildcardPathSuffix,
     })
   }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,15 +2,64 @@ import { ParseRoutesOptions, Protocol, Route, RouteParam } from './types'
 import { validateProtocol } from './validation'
 import { InvalidPatternError } from './errors'
 
-function routeSpecificity(url: URL) {
+const WILDCARD_HOSTNAME_PLACEHOLDER = 'wildcard'
+const PROTOCOL_SEPARATOR = '://'
+const PROTOCOL_PATTERN = /^[a-z0-9+\-.]+$/i
+
+export type UrlParts = {
+  protocolPrefix: string
+  hostname: string
+  rest: string
+}
+
+/**
+ * The reason we require manually parsing URLs instead of just passing it to URL()
+ * is that URL() constructor in the browser cannot handle parsing wildcards like `*.example.com`.
+ * Which is not obvious, since new URL('*.example.com') works in Node.
+ */
+export function splitUrlInput(urlInput: string): UrlParts | null {
+  const protocolIndex = urlInput.indexOf(PROTOCOL_SEPARATOR)
+  if (protocolIndex <= 0) {
+    // Fully qualified URLs (including protocol) are expected
+    return null
+  }
+
+  const protocol = urlInput.slice(0, protocolIndex)
+  if (!PROTOCOL_PATTERN.test(protocol)) {
+    return null
+  }
+
+  const hostnameStart = protocolIndex + PROTOCOL_SEPARATOR.length
+  const pathStart = urlInput.indexOf('/', hostnameStart)
+  const hostnameEnd = pathStart === -1 ? urlInput.length : pathStart
+
+  return {
+    protocolPrefix: urlInput.slice(0, hostnameStart),
+    hostname: urlInput.slice(hostnameStart, hostnameEnd),
+    rest: urlInput.slice(hostnameEnd),
+  }
+}
+
+/**
+ * We need this to replace `*` with a placeholder in the hostname so that the URL can be parsed by the URL() constructor.
+ */
+export function normalizeWildcardHostname(urlInput: string, urlParts: UrlParts | null): string {
+  if (!urlParts?.hostname.startsWith('*')) {
+    return urlInput
+  }
+  const wildcardHostname = `${WILDCARD_HOSTNAME_PLACEHOLDER}${urlParts.hostname.slice(1)}`
+  return `${urlParts.protocolPrefix}${wildcardHostname}${urlParts.rest}`
+}
+
+function routeSpecificity(hostname: string, pathname: string) {
   // Adapted from internal config service routing table implementation
-  const hostParts = url.host.split('.')
+  const hostParts = hostname.split('.')
   let hostScore = hostParts.length
   if (hostParts[0] === '*') {
     hostScore -= 2
   }
 
-  const pathParts = url.pathname.split('/')
+  const pathParts = pathname.split('/')
   let pathScore = pathParts.length
   if (pathParts[pathParts.length - 1] === '*') {
     pathScore -= 2
@@ -47,14 +96,17 @@ export function parseRoutes<Metadata>(
   for (const rawRoute of allRoutes) {
     const route = typeof rawRoute === 'string' ? rawRoute : rawRoute.url
     const metadata = typeof rawRoute === 'string' ? undefined : rawRoute.metadata
-    const hasProtocol = /^[a-z0-9+\-.]+:\/\//i.test(route)
+    const hasProtocol = route.indexOf(PROTOCOL_SEPARATOR) > 0
 
     let urlInput = route
     // If route is missing a protocol, give it one so it parses
     if (!hasProtocol) {
       urlInput = `https://${urlInput}`
     }
-    const url = parsePatternUrl(urlInput)
+    const urlParts = splitUrlInput(urlInput)
+    const rawHostname = urlParts?.hostname ?? ''
+    const urlInputForParse = normalizeWildcardHostname(urlInput, urlParts)
+    const url = parsePatternUrl(urlInputForParse)
 
     let protocol: Protocol | undefined
     if (hasProtocol) {
@@ -62,16 +114,22 @@ export function parseRoutes<Metadata>(
       protocol = url.protocol
     }
 
-    const specificity = sortBySpecificity ? routeSpecificity(url) : undefined
+    const allowHostnamePrefix = rawHostname.startsWith('*')
+    const anyHostname = rawHostname === '*'
+    const allowPathSuffix = url.pathname.endsWith('*')
+    const specificity = sortBySpecificity ? routeSpecificity(rawHostname, url.pathname) : undefined
 
-    const allowHostnamePrefix = url.hostname.startsWith('*')
-    const anyHostname = url.hostname === '*'
+    let hostname = url.hostname
     if (allowHostnamePrefix && !anyHostname) {
-      // Remove leading "*"
-      url.hostname = url.hostname.substring(1)
+      hostname = hostname.substring(WILDCARD_HOSTNAME_PLACEHOLDER.length)
     }
 
-    const allowPathSuffix = url.pathname.endsWith('*')
+    const pathContainsWildcard = url.pathname.includes('*')
+    const hostnameHasInfixWildcard = allowHostnamePrefix
+      ? rawHostname.slice(1).includes('*')
+      : rawHostname.includes('*')
+    const pathHasInfixWildcard = pathContainsWildcard && (!allowPathSuffix || url.pathname.slice(0, -1).includes('*'))
+
     if (allowPathSuffix) {
       // Remove trailing "*"
       url.pathname = url.pathname.substring(0, url.pathname.length - 1)
@@ -83,7 +141,7 @@ export function parseRoutes<Metadata>(
         'ERR_QUERY_STRING'
       )
     }
-    if (url.toString().includes('*') && !anyHostname) {
+    if (hostnameHasInfixWildcard || pathHasInfixWildcard) {
       throw new InvalidPatternError(
         `Route "${route}" contains an infix wildcard. This is not allowed.`,
         'ERR_INFIX_WILDCARD'
@@ -96,7 +154,7 @@ export function parseRoutes<Metadata>(
       specificity,
       protocol,
       wildcardHostnamePrefix: allowHostnamePrefix,
-      hostname: anyHostname ? '' : url.hostname,
+      hostname: anyHostname ? '' : hostname,
       path: url.pathname,
       wildcardPathSuffix: allowPathSuffix,
     })

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -109,18 +109,18 @@ export function parseRoutes<Metadata>(
       protocol = url.protocol
     }
 
-    const allowHostnamePrefix = rawHostname.startsWith('*')
     const anyHostname = rawHostname === '*'
-    const hasWildcardPathSuffix = url.pathname.endsWith('*')
     const specificity = sortBySpecificity ? routeSpecificity(rawHostname, url.pathname) : undefined
-
     let hostname = url.hostname
-    if (allowHostnamePrefix && !anyHostname) {
+
+    const hasWildcardHostnamePrefix = rawHostname.startsWith('*')
+    if (hasWildcardHostnamePrefix && !anyHostname) {
       hostname = hostname.substring(WILDCARD_HOSTNAME_PLACEHOLDER.length)
     }
 
+    const hasWildcardPathSuffix = url.pathname.endsWith('*')
     const pathContainsWildcard = url.pathname.includes('*')
-    const hostnameHasInfixWildcard = allowHostnamePrefix
+    const hostnameHasInfixWildcard = hasWildcardHostnamePrefix
       ? rawHostname.slice(1).includes('*')
       : rawHostname.includes('*')
     const pathHasInfixWildcard =
@@ -149,7 +149,7 @@ export function parseRoutes<Metadata>(
       metadata,
       specificity,
       protocol,
-      wildcardHostnamePrefix: allowHostnamePrefix,
+      wildcardHostnamePrefix: hasWildcardHostnamePrefix,
       hostname: anyHostname ? '' : hostname,
       path: url.pathname,
       wildcardPathSuffix: hasWildcardPathSuffix,


### PR DESCRIPTION
TLDR: 
* Refactored `parser.ts` to avoid putting `*.example` inside `URL()`, that's the whole fix
* Everything else is tests and plumbing

Slop summary:
This pull request introduces browser-based Playwright testing for URL pattern matching, improves wildcard handling in both the matcher logic and parser, and enhances documentation and test coverage for edge cases. The changes ensure that URL wildcards are correctly parsed and matched in both Node and browser environments, addressing inconsistencies and improving reliability.

**Testing infrastructure and documentation:**

* Added Playwright end-to-end tests and integrated them into CI workflow (`.github/workflows/build.yml`, `playwright.config.ts`, `__tests__/playwright/matcher.spec.ts`, `package.json`, `pnpm-lock.yaml`). [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R9-R32) [[2]](diffhunk://#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92R1-R17) [[3]](diffhunk://#diff-790fbb6f0e880723dfbfc2e7ad251b9f767782910b913477adfba76f28cc7786R1-R88) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17) [[5]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R48) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR33-R35) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR686-R690) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1700-R1704) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2563-R2572) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3935-R3938) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4973-R4975) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6005-R6012)
* Updated `README.md` with instructions for running Playwright and unit tests, highlighting browser-specific behaviors with wildcards.

**Wildcard parsing and matching improvements:**

* Refactored `src/parser.ts` to manually parse URLs and handle wildcards, ensuring the browser and Node environments behave consistently. Added `splitUrlInput` and `normalizeWildcardHostname` functions to enable parsing of patterns like `*.example.com`. Improved infix wildcard detection and error handling. [[1]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eL5-R62) [[2]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eL50-R132) [[3]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eL86-R144) [[4]](diffhunk://#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eL99-R157)
* Expanded matcher and parser unit tests to cover wildcard subdomains, infix wildcards, and error scenarios (`__tests__/matcher.test.ts`, `__tests__/parser.test.ts`, `__tests__/testCases.json`). [[1]](diffhunk://#diff-6344bea3bb65c25218fc80db4dd664ab9f223244e5b8a38178e801fd5f23d4b0R6-R9) [[2]](diffhunk://#diff-6344bea3bb65c25218fc80db4dd664ab9f223244e5b8a38178e801fd5f23d4b0L17-R28) [[3]](diffhunk://#diff-d78356ef46a77f6577a994a09b388b0c7040f8412482abd3582dd7c9ae3ecfc9R1-R134) [[4]](diffhunk://#diff-48e1a1787458be8099113e9a558f56be85c32639af9c03ab579a67ce14d8ecabR272-R285)

**Other improvements:**

* Added Playwright and related dependencies to `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R48) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR33-R35) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR686-R690) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1700-R1704) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2563-R2572) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3935-R3938) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4973-R4975) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6005-R6012)